### PR TITLE
Fixed issues with serializing of arrays to xml

### DIFF
--- a/lib/bandwidth-iris/lnp_checker.rb
+++ b/lib/bandwidth-iris/lnp_checker.rb
@@ -5,9 +5,10 @@ module BandwidthIris
     extend ClientWrapper
 
     def self.check(client, numbers, full_check = false)
+      list = if numbers.is_a?(Array) then numbers else [numbers] end
       data = {
         :number_portability_request => {
-          :tn_list => {:tn => numbers}
+          :tn_list => {:tn => list}
         }
       }
       client.make_request(:post, "#{client.concat_account_path(LNP_CHECKER_PATH)}?fullCheck=#{full_check}", data)[0]

--- a/lib/bandwidth-iris/version.rb
+++ b/lib/bandwidth-iris/version.rb
@@ -1,4 +1,4 @@
 module BandwidthIris
   # Version of this gem
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/spec/bandwidth-iris/client_spec.rb
+++ b/spec/bandwidth-iris/client_spec.rb
@@ -123,3 +123,17 @@ describe BandwidthIris::Client do
     end
   end
 end
+
+describe '#build_xml' do
+  client = nil
+  before :each do
+    client = Helper.get_client()
+  end
+
+  it 'should generate valid XML' do
+    expect(client.build_xml({root: {item: {value: '123'}}})).to eql('<?xml version="1.0" encoding="UTF-8"?><Root><Item><Value>123</Value></Item></Root>')
+    expect(client.build_xml({root: {item: [1,2,3]}})).to eql('<?xml version="1.0" encoding="UTF-8"?><Root><Item>1</Item><Item>2</Item><Item>3</Item></Root>')
+    expect(client.build_xml({root: {item: [{value: '111'}, {value: '222'}]}})).to eql('<?xml version="1.0" encoding="UTF-8"?><Root><Item><Value>111</Value></Item><Item><Value>222</Value></Item></Root>')
+    expect(client.build_xml({root: {item: [{value: [1,2,3]}, {value: '222'}]}})).to eql('<?xml version="1.0" encoding="UTF-8"?><Root><Item><Value>1</Value><Value>2</Value><Value>3</Value></Item><Item><Value>222</Value></Item></Root>')
+  end
+end

--- a/spec/bandwidth-iris/lnp_checker_spec.rb
+++ b/spec/bandwidth-iris/lnp_checker_spec.rb
@@ -19,6 +19,16 @@ describe BandwidthIris::LnpChecker do
       expect(result[:supported_rate_centers][:rate_center_group][:city]).to eql("City1")
       expect(result[:supported_rate_centers][:rate_center_group][:state]).to eql("State1")
     end
+
+    it 'should allow to use 1 number as string' do
+      number = '1111'
+      data = {:number_portability_request => {:tn_list => {:tn => number}}}
+      client.stubs.post('/v1.0/accounts/accountId/lnpchecker?fullCheck=true', client.build_xml(data)) {|env| [200, {}, Helper.xml['lnp_check']]}
+      result = LnpChecker.check(client, number, true)
+      expect(result[:supported_rate_centers][:rate_center_group][:rate_center]).to eql("Center1")
+      expect(result[:supported_rate_centers][:rate_center_group][:city]).to eql("City1")
+      expect(result[:supported_rate_centers][:rate_center_group][:state]).to eql("State1")
+    end
   end
 
 end


### PR DESCRIPTION
Close #2 
Also now both forms `LnpChecker.check(client, '+1234567890', true)` and `LnpChecker.check(client, ['+1234567890'], true)` are supported